### PR TITLE
Add entry point and dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Read the Docs Client",
   "author": "Anthony Johnson <anthony@readthedocs.com>",
   "dependencies": {
+    "reqwest": "^1.1.5"
   },
   "devDependencies": {
     "bower": "^1.3.12",
@@ -17,6 +18,7 @@
     "jsdom": "^3.1.0",
     "proxyquire": "^1.3.1"
   },
+  "main": "lib/readthedocs.js",
   "private": true,
   "license": "MIT"
 }


### PR DESCRIPTION
This module can't be used by npm directly because it doesn't declare its dependencies and it doesn't specify an entry point. This PR fixes that.